### PR TITLE
Add test coverage to groupProductsByCategory()

### DIFF
--- a/server/src/main/java/umm3601/product/ProductController.java
+++ b/server/src/main/java/umm3601/product/ProductController.java
@@ -111,6 +111,7 @@ public class ProductController {
                             .append("brand", "$brand")
                             .append("description", "$description")
                             .append("image", "$image")
+                            .append("category", "$category")
                             .append("lifespan", "$lifespan")
                             .append("location", "$location")
                             .append("notes", "$notes")
@@ -122,7 +123,8 @@ public class ProductController {
                     Projections.fields(
                         Projections.computed("category", "$_id"),
                         Projections.include("count", "products"),
-                        Projections.excludeId()))),
+                        Projections.excludeId())),
+                Aggregates.sort(Sorts.ascending("_id"))),
             CategorySortItem.class)
         .into(new ArrayList<>());
 

--- a/server/src/test/java/umm3601/product/ProductControllerSpec.java
+++ b/server/src/test/java/umm3601/product/ProductControllerSpec.java
@@ -278,6 +278,23 @@ public class ProductControllerSpec {
     return product;
   }
 
+
+  /**
+   * A little helper method that assumes that the given context
+   * body contains a list of CategorySortItems, and extracts and returns
+   * that list.
+   *
+   * @param ctx the `Context` whose body is assumed to contain
+   *            a list of `CategorySortItem`.
+   * @return the list of `CategorySortItem` extracted from the given `Context`.
+   */
+  private CategorySortItem[] getGroupedItems(Context ctx) {
+    String result = ctx.resultString();
+    CategorySortItem[] items = javalinJackson.fromJsonString(result, CategorySortItem[].class);
+    return items;
+  }
+
+
   @Test
   public void canGetAllProducts() throws IOException {
     // Create our fake Javalin context
@@ -400,6 +417,26 @@ public class ProductControllerSpec {
     assertThrows(NotFoundResponse.class, () -> {
       productController.getProductByID(ctx);
     });
+  }
+
+  @Test
+  public void groupProductsByCategory() {
+    Context ctx = mockContext("api/products/group");
+
+    productController.groupProductsByCategory(ctx);
+    CategorySortItem[] returnedItems = getGroupedItems(ctx);
+
+    //check that there are 5 different categories with items
+    assertEquals(5, returnedItems.length);
+
+    for (CategorySortItem item : returnedItems) {
+      //check that the count is equal to the number of products
+      assertEquals(item.count, item.products.size());
+      //check that each item has the correct category
+      for (Product p: item.products) {
+        assertEquals(item.category, p.category);
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Added JUnit coverage to check the groupProductsByCategory method, as well as fixed the sorting order, and passed through the category of the products being returned.